### PR TITLE
Krah/buildinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ ScoverageKeys.coverageFailOnMinimum := false
   * the only version control system allowed is Git
 * Support scala 2.11 projects
 * Sbt-BuildInfo [(GitHub)](https://github.com/sbt/sbt-buildinfo)
+  * explicitly enable per project i.e. `enablePlugins(sbtbuildinfo.BuildInfoPlugin)`
+  * automatically excluded from test coverage
   * calling `compile` now automatically generates buildinfo.BuildInfo.scala
   * customize the package name in sbt e.g. `buildInfoPackage := "com.socrata.sbtplugins"`
   * easily populate a version http endpoint or whatnot by calling `BuildInfo.toJson`

--- a/build.sbt
+++ b/build.sbt
@@ -46,4 +46,5 @@ assemblyMergeStrategy in assembly := {
 
 sbtrelease.ReleasePlugin.ReleaseKeys.releaseProcess := CloudbeesPlugin.cloudbeesReleaseSteps
 
+enablePlugins(sbtbuildinfo.BuildInfoPlugin)
 buildInfoPackage := "com.socrata.sbtplugins"

--- a/src/main/scala/com/socrata/sbtplugins/BuildInfoPlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/BuildInfoPlugin.scala
@@ -5,12 +5,14 @@ import sbt.Keys._
 import sbt._
 import sbtbuildinfo.BuildInfoPlugin.autoImport._
 import sbtbuildinfo.{BuildInfoPlugin => OriginalPlugin}
+import scoverage.ScoverageSbtPlugin.ScoverageKeys.coverageExcludedPackages
 
 object BuildInfoPlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
-  override def requires: Plugins = plugins.JvmPlugin
+  override def requires: Plugins = plugins.JvmPlugin && OriginalPlugin
 
-  override def projectSettings: Seq[Def.Setting[_]] = OriginalPlugin.projectSettings ++ Seq(
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    coverageExcludedPackages := "%s.BuildInfo;%s".format(buildInfoPackage, coverageExcludedPackages.value),
     buildInfoKeys ++= Seq[BuildInfoKey](
       name,
       version,

--- a/src/main/scala/com/socrata/sbtplugins/BuildInfoPlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/BuildInfoPlugin.scala
@@ -12,7 +12,7 @@ object BuildInfoPlugin extends AutoPlugin {
   override def requires: Plugins = plugins.JvmPlugin && OriginalPlugin
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
-    coverageExcludedPackages := "%s.BuildInfo;%s".format(buildInfoPackage, coverageExcludedPackages.value),
+    coverageExcludedPackages := "%s.BuildInfo;%s".format(buildInfoPackage.value, coverageExcludedPackages.value),
     buildInfoKeys ++= Seq[BuildInfoKey](
       name,
       version,

--- a/src/sbt-test/PluginTests/BuildInfo/build.sbt
+++ b/src/sbt-test/PluginTests/BuildInfo/build.sbt
@@ -1,5 +1,7 @@
 import scala.io.Source
 
+enablePlugins(sbtbuildinfo.BuildInfoPlugin)
+
 val gitInit = TaskKey[Unit]("gitInit")
 gitInit := {
   Process(Seq("git", "init")).!!

--- a/src/sbt-test/PluginTests/BuildInfo/test
+++ b/src/sbt-test/PluginTests/BuildInfo/test
@@ -10,3 +10,7 @@ $ exists target/scala-2.10/src_managed/main/sbt-buildinfo/BuildInfo.scala
 > buildInfo
 $ exists target/scala-2.10/src_managed/main/sbt-buildinfo/BuildInfo.scala
 > buildInfoContainsPackage
+
+# scoverage should exclude buildinfo generated source
+> coverage
+> test


### PR DESCRIPTION
What's new 
--------
+ explicitly enable buildinfo per project
  + limit unnecessary generated code
  + avoid assembly merge collisions
+ exclude buildinfo from scoverage
