### PR TITLE
allow case class unapply

### DIFF
--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -25,7 +25,7 @@
     </check>
     <check level="error" class="org.scalastyle.scalariform.FieldNamesChecker" enabled="true">
         <parameters>
-            <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+            <parameter name="regex"><![CDATA[^([A-Za-z0-9]*\()?([a-z][A-Za-z0-9]*[\s,]*)+(\))?$]]></parameter>
         </parameters>
     </check>
     <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -25,7 +25,7 @@
     </check>
     <check level="warning" class="org.scalastyle.scalariform.FieldNamesChecker" enabled="true">
         <parameters>
-            <parameter name="regex"><![CDATA[^[a-z][A-Za-z0-9]*$]]></parameter>
+            <parameter name="regex"><![CDATA[^([A-Za-z0-9]*\()?([a-z][A-Za-z0-9]*[\s,]*)+(\))?$]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">


### PR DESCRIPTION
as seen in https://github.com/scalastyle/scalastyle/issues/149.
this regex allows case class unapply to extract values directly, and also allows tuple field definition.
[`^([A-Za-z0-9]*\()?([a-z][A-Za-z0-9]*[\s,]*`)+(\))?$](http://regexper.com/#%5E(%5BA-Za-z0-9%5D*%5C()%3F(%5Ba-z%5D%5BA-Za-z0-9%5D*%5B%5Cs%2C%5D*)%2B(%5C))%3F%24)