### PR TITLE
allow field name almost anything

### DIFF
--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -25,7 +25,7 @@
     </check>
     <check level="error" class="org.scalastyle.scalariform.FieldNamesChecker" enabled="true">
         <parameters>
-            <parameter name="regex"><![CDATA[^([A-Za-z0-9]*\()?([a-z][A-Za-z0-9]*[\s,]*)+(\))?$]]></parameter>
+            <parameter name="regex">^([A-Za-z0-9]*\()?([a-z][A-Za-z0-9]*[\s,]*)+(\))?$</parameter>
         </parameters>
     </check>
     <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">

--- a/src/main/resources/scalastyle-config.xml
+++ b/src/main/resources/scalastyle-config.xml
@@ -25,7 +25,7 @@
     </check>
     <check level="error" class="org.scalastyle.scalariform.FieldNamesChecker" enabled="true">
         <parameters>
-            <parameter name="regex">^([A-Za-z0-9]*\()?([a-z][A-Za-z0-9]*[\s,]*)+(\))?$</parameter>
+            <parameter name="regex"><![CDATA[^[A-Za-z0-9(]+$]]></parameter>
         </parameters>
     </check>
     <check level="error" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -25,7 +25,7 @@
     </check>
     <check level="warning" class="org.scalastyle.scalariform.FieldNamesChecker" enabled="true">
         <parameters>
-            <parameter name="regex"><![CDATA[^([A-Za-z0-9]*\()?([a-z][A-Za-z0-9]*[\s,]*)+(\))?$]]></parameter>
+            <parameter name="regex">^([A-Za-z0-9]*\()?([a-z][A-Za-z0-9]*[\s,]*)+(\))?$</parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">

--- a/src/main/resources/scalastyle-test-config.xml
+++ b/src/main/resources/scalastyle-test-config.xml
@@ -25,7 +25,7 @@
     </check>
     <check level="warning" class="org.scalastyle.scalariform.FieldNamesChecker" enabled="true">
         <parameters>
-            <parameter name="regex">^([A-Za-z0-9]*\()?([a-z][A-Za-z0-9]*[\s,]*)+(\))?$</parameter>
+            <parameter name="regex"><![CDATA[^[A-Za-z0-9(]+$]]></parameter>
         </parameters>
     </check>
     <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">

--- a/src/test/scala/com/socrata/sbtplugins/StylePluginSpec.scala
+++ b/src/test/scala/com/socrata/sbtplugins/StylePluginSpec.scala
@@ -1,10 +1,12 @@
 package com.socrata.sbtplugins
 
 import com.socrata.sbtplugins.StylePlugin._
+import org.scalastyle._
+import org.scalastyle.scalariform.FieldNamesChecker
 import org.scalatest.{FunSuiteLike, Matchers}
-import sbt._
+import _root_.sbt.{Level => _, _}
 
-class StylePluginSpec extends FunSuiteLike with Matchers{
+class StylePluginSpec extends CheckerTest {
   test("triggers on all requirements") {
     trigger should equal(AllRequirements)
   }
@@ -15,5 +17,49 @@ class StylePluginSpec extends FunSuiteLike with Matchers{
 
   test("has project settings") {
     projectSettings.isEmpty should equal(false)
+  }
+
+  val classUnderTest = classOf[FieldNamesChecker]
+  val keyUnderTest = "field.name"
+  test("scalastyle - allow case class unapply") {
+    val source =
+      """
+        |package foobar
+        |
+        |class CaseClassUnapply {
+        |  val Foo(bar) = Foo("42")
+        |  val (a: Int, b: Int) = (3, 5)
+        |}
+        |
+        |case class Foo(bar: String)
+      """.stripMargin
+
+    val originalRegex = "^[a-z][A-Za-z0-9]*$"
+    assertErrors(List(
+      StyleError(null, classUnderTest, keyUnderTest, Level("warning"), List(originalRegex), Some(5), Some(6), None),
+      StyleError(null, classUnderTest, keyUnderTest, Level("warning"), List(originalRegex), Some(6), Some(6), None)
+    ), source)
+
+    val awfulRegex = "^[A-Za-z0-9(]+$"
+    assertErrors(Nil, source, params = Map("regex" -> awfulRegex))
+  }
+}
+
+// partial pasta from https://github.com/scalastyle/scalastyle/blob/master/src/test/scala/org/scalastyle/file/CheckerTest.scala
+trait CheckerTest extends FunSuiteLike with Matchers {
+  protected val classUnderTest: Class[_ <: Checker[_]]
+
+  object NullFileSpec extends FileSpec {
+    def name: String = ""
+  }
+
+  protected def assertErrors[T <: FileSpec](expected: List[Message[T]], source: String, params: Map[String, String] = Map(),
+                                            customMessage: Option[String] = None, commentFilter: Boolean = true, customId: Option[String] = None) = {
+    val classes =  List(ConfigurationChecker(classUnderTest.getName, WarningLevel, enabled = true, params, customMessage, customId))
+    val configuration = ScalastyleConfiguration("", commentFilter, classes)
+
+    val expectedStr = expected.mkString("\n")
+    val actualStr = new CheckerUtils().verifySource(configuration, classes, NullFileSpec, source).mkString("\n")
+    expectedStr should be (actualStr)
   }
 }


### PR DESCRIPTION
as seen in https://github.com/scalastyle/scalastyle/issues/149.

we hoped that this awesome regex allows case class unapply to extract values directly, and also allows tuple field definition.
[`^([A-Za-z0-9]*\()?([a-z][A-Za-z0-9]*[\s,]*`)+(\))?$](http://regexper.com/#%5E(%5BA-Za-z0-9%5D*%5C()%3F(%5Ba-z%5D%5BA-Za-z0-9%5D*%5B%5Cs%2C%5D*)%2B(%5C))%3F%24)

instead this awful regex matches what the ast parser has decided to check (either the case class name, or the opening paren only).
`^[A-Za-z0-9(]+$`