### PR TITLE
test code is not checked in findbugs

### DIFF
--- a/src/main/scala/com/socrata/sbtplugins/JavaFindBugsPlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/JavaFindBugsPlugin.scala
@@ -49,6 +49,7 @@ object JavaFindBugsPlugin extends AutoPlugin {
 
   val configSettings: Seq[Setting[_]] = Seq(
     findbugsFailOnError := true,
+    findbugsFailOnError in Test := false,
     findbugsReport := {
       val reportPath = findbugsReportPath.value.getOrElse(throw new IllegalArgumentException)
       JavaFindBugsXml(reportPath) match {

--- a/src/sbt-test/PluginTests/JavaFindBugs/build.sbt
+++ b/src/sbt-test/PluginTests/JavaFindBugs/build.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test

--- a/src/sbt-test/PluginTests/JavaFindBugs/src/test/java/ATest.java
+++ b/src/sbt-test/PluginTests/JavaFindBugs/src/test/java/ATest.java
@@ -1,0 +1,10 @@
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class ATest {
+    @Test
+    public void testNothing() {
+        System.out.println("Hello 2 World!");
+        assertEquals(2, 1 + 1);
+    }
+}

--- a/src/sbt-test/PluginTests/JavaFindBugs/src/test/java/BTest.java
+++ b/src/sbt-test/PluginTests/JavaFindBugs/src/test/java/BTest.java
@@ -1,0 +1,9 @@
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class BTest {
+    @Test
+    public void testSmells() {
+        assertEquals(1, 1234 >> 42);
+    }
+}

--- a/src/sbt-test/PluginTests/JavaFindBugs/test
+++ b/src/sbt-test/PluginTests/JavaFindBugs/test
@@ -24,3 +24,7 @@ $ delete src/main/java/AShift.java
 > clean
 > compile
 > findbugsReportInline
+
+# test code is unchecked
+> test
+> test:findbugsReportInline


### PR DESCRIPTION
A first attempt at running findbugs on test-classes went horribly wrong. So for now continuing without findbugs on test code.

```
[info] Java FindBugs starting.
[error] Warnings generated: 24
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/BuildInfoSpec.scala:5. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/BuildInfoSpec.scala:5. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/CloudbeesPluginSpec.scala:8. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/CloudbeesPluginSpec.scala:8. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/CoreSettingsPluginSpec.scala:7. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/CoreSettingsPluginSpec.scala:7. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/CoveragePluginSpec.scala:7. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/CoveragePluginSpec.scala:7. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/DependencyGraphPluginSpec.scala:7. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/DependencyGraphPluginSpec.scala:7. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/JArchiveSpec.scala:6. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/JArchiveSpec.scala:6. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/MimaPluginSpec.scala:7. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/MimaPluginSpec.scala:7. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/ScalaTestPluginSpec.scala:7. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/ScalaTestPluginSpec.scala:7. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/StringPathSpec.scala:6. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/StringPathSpec.scala:6. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/StylePluginSpec.scala:9. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/StylePluginSpec.scala:9. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/WebDavPluginSpec.scala:10. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/WebDavPluginSpec.scala:10. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/findbugs/JavaFindBugsSpec.scala:7. Use of identifier that is a keyword in later versions of Java
[error] BAD_PRACTICE Nm NM_FUTURE_KEYWORD_USED_AS_MEMBER_IDENTIFIER: com/socrata/sbtplugins/findbugs/JavaFindBugsSpec.scala:7. Use of identifier that is a keyword in later versions of Java
[info] FindBugs Summary, ran 2015-08-14T11:17:16.000-07:00:
[info]   bugs: 24
[info]   java: 1.7.0_80, vm: 24.80-b11
[info]   cpu time: 36.91 s, gc time: 0.65 s, time elapsed: 12.81 s
[info]   megabytes peak: 510.03, alloc: 910.5
[info]   packages: 2, classes: 316, referenced: 962, size: 7172
[info]     com.socrata.sbtplugins types:221 size:5579 bugs:22
[info]     com.socrata.sbtplugins.findbugs types:95 size:1593 bugs:2
[trace] Stack trace suppressed: run last compile:findbugsReport for the full output.
[error] (compile:findbugsReport) Java FindBugs has 24 errors.
[error] Total time: 17 s, completed Aug 14, 2015 11:17:31 AM

```