### PR TITLE
Check for styleConfig as file in project before looking in jar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,6 @@ addSbtPlugin("de.johoop" % "findbugs4sbt" % "1.4.0")
 
 (StylePlugin.StyleKeys.styleConfigName in Compile) := None
 (StylePlugin.StyleKeys.styleConfigName in Test) := None
-(StylePlugin.StyleKeys.styleFailOnError in Test) := false
 (scalastyleConfig in Compile) := baseDirectory.value / "src/main/resources/scalastyle-config.xml"
 (scalastyleConfig in Test) := baseDirectory.value / "src/main/resources/scalastyle-test-config.xml"
 

--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ addSbtPlugin("de.johoop" % "findbugs4sbt" % "1.4.0")
 
 (StylePlugin.StyleKeys.styleConfigName in Compile) := None
 (StylePlugin.StyleKeys.styleConfigName in Test) := None
+(StylePlugin.StyleKeys.styleFailOnError in Test) := false
 (scalastyleConfig in Compile) := baseDirectory.value / "src/main/resources/scalastyle-config.xml"
 (scalastyleConfig in Test) := baseDirectory.value / "src/main/resources/scalastyle-test-config.xml"
 

--- a/src/main/scala/com/socrata/sbtplugins/StylePlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/StylePlugin.scala
@@ -43,8 +43,11 @@ object StylePlugin extends AutoPlugin {
       val configXml = StyleKeys.styleConfigName.value match {
         case Some(f) =>
           val file = new File(f)
-          if (file.exists) file
-          else new JArchive(getClass.getResource(f)).getFileFromJar(target.value / f, state.value.log)
+          if (file.exists) {
+            file
+          } else {
+            new JArchive(getClass.getResource(f)).getFileFromJar(target.value / f, state.value.log)
+          }
         case None => scalastyleConfig.value
       }
       val configUrl = None

--- a/src/main/scala/com/socrata/sbtplugins/StylePlugin.scala
+++ b/src/main/scala/com/socrata/sbtplugins/StylePlugin.scala
@@ -41,7 +41,10 @@ object StylePlugin extends AutoPlugin {
     StyleKeys.styleCheck := {
       val args = Seq()
       val configXml = StyleKeys.styleConfigName.value match {
-        case Some(f) => new JArchive(getClass.getResource(f)).getFileFromJar(target.value / f, state.value.log)
+        case Some(f) =>
+          val file = new File(f)
+          if (file.exists) file
+          else new JArchive(getClass.getResource(f)).getFileFromJar(target.value / f, state.value.log)
         case None => scalastyleConfig.value
       }
       val configUrl = None


### PR DESCRIPTION
This change allows you to include a scalastyle config file in your project (which is useful if you
want to override the default style config, for example).